### PR TITLE
Refactor: Improve tip calculation logic for clarity

### DIFF
--- a/Project-02-tip-calculator/main.py
+++ b/Project-02-tip-calculator/main.py
@@ -1,7 +1,10 @@
-print("welcome to tipcalculator")
-bill=int(input("What was total bill$ ?\n"))
-tip_percent=float(input("What percentage tip would you like to give 10%, 12% or 15% ?  \n"))
-distribution=int(input("How many people to split the bill?\n"))
-tip=(bill/distribution)*(1+(tip_percent/100))
-ftip= round(tip,2)
-print(f"Each person should pay ${ftip}")
+print("Welcome to Tip Calculator!")
+
+bill = float(input("What was the total bill? $ "))
+tip_percent = float(input("What percentage tip would you like to give? 10, 12, or 15? "))
+distribution = int(input("How many people to split the bill? "))
+
+total_with_tip = bill * (1 + tip_percent / 100)
+each_person_pays = round(total_with_tip / distribution, 2)
+
+print(f"Each person should pay: ${each_person_pays}")


### PR DESCRIPTION
Refactor tip calculation to improve clarity and prevent confusion in issue #7 

The previous implementation calculated each person's share by first dividing the bill and then applying the tip percentage:

    tip = (bill / distribution) * (1 + tip_percent / 100)

While mathematically correct due to the commutative property of multiplication and division, this approach was less intuitive and could lead to misunderstanding. **The new implementation first calculates the total bill including the tip, and then divides by the number of people:**

    total_with_tip = bill * (1 + tip_percent / 100)
    each_person_pays = total_with_tip / distribution

**This makes the calculation easier to understand and aligns with common expectations when splitting a bill.**
